### PR TITLE
Migrating to CodeClimate

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,11 +35,13 @@ jobs:
       - name: running unit tests
         run: mvn verify -fae -DskipITs $MVN_ARGS
 
-      - name: publishing code coverage report
+      - name: publishing code coverage report to codeclimate
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: |
-          curl -s https://codecov.io/bash > $HOME/codecov-bash.sh && chmod +x $HOME/codecov-bash.sh
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
           build/publishCodeCoverage.sh
 
       - name: running integration tests

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Javadoc](https://img.shields.io/static/v1?label=javadoc&message=latest&color=blue)](http://IBM.github.io/scc-java-sdk)
 [![Release](https://img.shields.io/github/v/release/IBM/scc-java-sdk)](https://img.shields.io/github/v/release/IBM/scc-java-sdk)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![codecov](https://codecov.io/gh/IBM/scc-java-sdk/branch/main/graph/badge.svg?token=9E3PB14AKI)](https://codecov.io/gh/IBM/scc-java-sdk)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/c01d10d1017a7fa7c8cb/test_coverage)](https://codeclimate.com/github/IBM/scc-java-sdk/test_coverage)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![Maven Central](https://img.shields.io/maven-central/v/com.ibm.cloud/scc)](https://maven-badges.herokuapp.com/maven-central/com.ibm.cloud/scc)
+[![Maven Central](https://img.shields.io/maven-central/v/com.ibm.cloud/scc.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.ibm.cloud%22%20AND%20a:%22scc%22)
 
 # IBM Cloud Security & Compliance Center Java SDK Version 1.0.2
 Java client library to interact with various [IBM Cloud Security & Compliance Center](https://cloud.ibm.com/docs?tab=api-docs&category=platform_services%2Csecurity).

--- a/build/publishCodeCoverage.sh
+++ b/build/publishCodeCoverage.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-# This script will publish code coverage info for a build of the main branch
+# This script will publish code coverage info for a build of the master branch
 # or a tagged release.
 
-if [[ -n "${TRAVIS_TAG}" || "${TRAVIS_BRANCH}" == "main" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
-    printf ">>>>> Publishing code coverage info for branch: %s\n" ${TRAVIS_BRANCH}
-    $HOME/codecov-bash.sh -s modules/coverage-reports/target/site/jacoco-aggregate -t $CODECOV_TOKEN
-else
-    printf ">>>>> Bypassing code coverage publish step for feature branch/PR build.\n"
-fi
-   
+printf ">>>>> Publishing code coverage info\n"
+
+JACOCO_SOURCE_PATH=modules/common/src/main/java ./cc-test-reporter format-coverage modules/common/target/site/jacoco/jacoco.xml -d -o common.json -t jacoco
+JACOCO_SOURCE_PATH=modules/configuration-governance/src/main/java ./cc-test-reporter format-coverage modules/configuration-governance/target/site/jacoco/jacoco.xml -d -o configuration-governance.json -t jacoco
+JACOCO_SOURCE_PATH=modules/findings/src/main/java ./cc-test-reporter format-coverage modules/findings/target/site/jacoco/jacoco.xml -d -o findings.json -t jacoco
+JACOCO_SOURCE_PATH=modules/notifications/src/main/java ./cc-test-reporter format-coverage modules/notifications/target/site/jacoco/jacoco.xml -d -o notifications.json -t jacoco
+
+./cc-test-reporter sum-coverage common.json configuration-governance.json findings.json notifications.json -o coverage.json -d
+
+./cc-test-reporter upload-coverage --input coverage.json


### PR DESCRIPTION
For code coverage, and quality record keeping we are going to use CodeClimate from now on. Codecov.io is no longer permitted as per [CISO](https://w3.ibm.com/w3publisher/ciso-vulnerability-management/high-risk-software/codecov)